### PR TITLE
Add ability to pass CLI options to PHP

### DIFF
--- a/spec/Bex/Behat/Context/TestRunnerContextSpec.php
+++ b/spec/Bex/Behat/Context/TestRunnerContextSpec.php
@@ -92,7 +92,7 @@ class TestRunnerContextSpec extends ObjectBehavior
     {
         $processFactory->createBehatProcess(
             Argument::containingString(sys_get_temp_dir() .'/behat-test-runner'),
-            Argument::any()
+            Argument::cetera()
         )->shouldBeCalled()->willReturn($process);
         $process->run()->shouldBeCalled();
 
@@ -121,24 +121,21 @@ class TestRunnerContextSpec extends ObjectBehavior
         $this->iHaveAWebServerRunningOnAddressAndPort('localhost', '8080');
     }
 
-    function it_can_detect_when_there_was_no_failing_tests_but_expected(
-        ProcessFactory $processFactory,
-        Process $process
-    ) {
-        $processFactory->createBehatProcess(Argument::any(), Argument::any())->willReturn($process);
+    function it_can_detect_when_there_was_no_failing_tests_but_expected(Process $behatProcess)
+    {
         $this->createWorkingDirectory();
         $this->iRunBehat();
 
-        $process->isSuccessful()->willReturn(true);
+        $behatProcess->isSuccessful()->willReturn(true);
         $this->shouldThrow(
             new \RuntimeException('Behat did not find any failing scenario.')
         )->duringIShouldSeeAFailingTest();
 
-        $process->isSuccessful()->willReturn(false);
+        $behatProcess->isSuccessful()->willReturn(false);
         $this->shouldNotThrow('\RuntimeException')->duringIShouldSeeAFailingTest();
     }
 
-    function it_does_not_run_browser_when_broser_binary_is_not_set(
+    function it_does_not_run_browser_when_browser_binary_is_not_set(
         Filesystem $filesystem,
         ProcessFactory $processFactory,
         Process $webServerProcess,
@@ -176,6 +173,16 @@ class TestRunnerContextSpec extends ObjectBehavior
         $this->shouldThrow('\RuntimeException')->duringPrintTesterOutputOnFailure($scope);
     }
 
+    function it_can_pass_command_line_options_to_php_when_running_behat(
+        ProcessFactory $processFactory,
+        Process $behatProcess
+    ) {
+        $processFactory->createBehatProcess(Argument::any(), Argument::any(), '-x foo')->willReturn($behatProcess)
+            ->shouldBeCalled();
+
+        $this->iRunBehat('', '-x foo');
+    }
+
     private function initFilesystemDouble($filesystem)
     {
         $filesystem->remove(Argument::type('string'))->willReturn(null);
@@ -184,6 +191,6 @@ class TestRunnerContextSpec extends ObjectBehavior
 
     private function initProcessFactoryDouble(ProcessFactory $processFactory, Process $behatProcess)
     {
-        $processFactory->createBehatProcess(Argument::any(), Argument::any())->willReturn($behatProcess);
+        $processFactory->createBehatProcess(Argument::cetera())->willReturn($behatProcess);
     }
 }

--- a/src/Services/ProcessFactory.php
+++ b/src/Services/ProcessFactory.php
@@ -24,15 +24,16 @@ class ProcessFactory
     }
 
     /**
-     * @param  string $workingDirectory
-     * @param  string $parameters
-     *
+     * @param string $workingDirectory
+     * @param string $parameters
+     * @param string $phpParameters PHP CLI arguments @link http://php.net/manual/en/features.commandline.options.php
+     * 
      * @return Process
      */
-    public function createBehatProcess($workingDirectory, $parameters = '')
+    public function createBehatProcess($workingDirectory, $parameters = '', $phpParameters = '')
     {
         return new Process(
-            sprintf('%s %s %s', $this->phpBin, escapeshellarg(BEHAT_BIN_PATH), $parameters),
+            sprintf('%s %s %s %s', $this->phpBin, $phpParameters, escapeshellarg(BEHAT_BIN_PATH), $parameters),
             $workingDirectory
         );
     }

--- a/src/TestRunnerContext.php
+++ b/src/TestRunnerContext.php
@@ -201,12 +201,13 @@ class TestRunnerContext implements SnippetAcceptingContext
 
     /**
      * @When I run Behat
-     * @When I run Behat with :paramters parameter
-     * @When I run Behat with :paramters parameters
+     * @When /^I run Behat with "([^"]*)" parameter[s]?$/
+     * @When /^I run Behat with "([^"]*)" parameter[s]? and with PHP CLI arguments "([^"]*)"$/
+     * @When I run Behat with PHP CLI arguments :phpParams
      */
-    public function iRunBehat($parameters = '')
+    public function iRunBehat($parameters = '', $phpParameters = '')
     {
-        $this->runBehat($parameters);
+        $this->runBehat($parameters, $phpParameters);
     }
 
     /**
@@ -267,13 +268,14 @@ class TestRunnerContext implements SnippetAcceptingContext
     }
 
     /**
-     * @param  string $parameters
+     * @param string $parameters
+     * @param string $phpParameters
      *
      * @return void
      */
-    private function runBehat($parameters = '')
+    private function runBehat($parameters = '', $phpParameters = '')
     {
-        $behatProcess = $this->processFactory->createBehatProcess($this->workingDirectory, $parameters);
+        $behatProcess = $this->processFactory->createBehatProcess($this->workingDirectory, $parameters, $phpParameters);
         $this->behatProcess = $behatProcess;
         $this->processes[] = $this->behatProcess;
         $behatProcess->run();


### PR DESCRIPTION
Add a new argument to iRunBehat() step method, to be able to pass CLI options to PHP when the secondary Behat process is executed by PHP.