### PR TITLE
Allow newer symfony/process package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php" : ">=5.4",
         "behat/behat" : "^3.0.0",
-        "symfony/process" : "^2.7.0"
+        "symfony/process" : "^2.7.0|^4.4"
     },
     "require-dev": {
         "phpspec/phpspec" : "2.4.0-alpha2"


### PR DESCRIPTION
I am not sure about which versions are fine, but I need to install it alongside symfony process 4.4, so testing it now to see if it works.

*update:* working fine in my case :) 